### PR TITLE
Add hint for len(F) error

### DIFF
--- a/magic_filter/magic.py
+++ b/magic_filter/magic.py
@@ -94,6 +94,11 @@ class MagicFilter:
             return self._extend(SelectorOperation(inner=item))
         return self._extend(GetItemOperation(key=item))
 
+    def __len__(self) -> int:
+        raise TypeError(
+            f"Length can't be taken using len() function. Use {type(self).__name__}.len() instead."
+        )
+
     def __eq__(self: MagicT, other: Any) -> MagicT:  # type: ignore
         return self._extend(ComparatorOperation(right=other, comparator=operator.eq))
 

--- a/tests/test_len.py
+++ b/tests/test_len.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from magic_filter import F
@@ -7,5 +9,8 @@ class TestLen:
     def test_has_no_len(self):
         # F object doesn't have len(). But F.len() can be used,
         # so it will raise error with suggestion to use F.len()
-        with pytest.raises(TypeError):
+        error_message = (
+            "Length can't be taken using len() function. Use MagicFilter.len() instead."
+        )
+        with pytest.raises(TypeError, match=re.escape(error_message)):
             len(F)

--- a/tests/test_len.py
+++ b/tests/test_len.py
@@ -1,0 +1,11 @@
+import pytest
+
+from magic_filter import F
+
+
+class TestLen:
+    def test_has_no_len(self):
+        # F object doesn't have len(). But F.len() can be used,
+        # so it will raise error with suggestion to use F.len()
+        with pytest.raises(TypeError):
+            len(F)


### PR DESCRIPTION
# Description
This change adds a helpful error message when the len() function is used on an object of the MagicFilter class.
Previously, calling len() on an instance of MagicFilter would result in a TypeError, but the error message did not provide any guidance on how to correct the issue. 

With this change, a new error message will be displayed, suggesting that the user should use the len() method of the MagicFilter class instead of the built-in len() function.

I am not sure about the message of hint, but anyway I think that it's helpful.
```python
>>> len(F)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: object of type 'MagicFilter' has no len()
>>> len(F)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/project/magic-filter/magic_filter/magic.py", line 98, in __len__
    raise TypeError(
TypeError: Length can't be taken using len() function. Use MagicFilter.len() instead.
```

# How Has This Been Tested?
SImple test declared in tests/test_len.py
