### PR TITLE
Use abstract Container type for `in` operations

### DIFF
--- a/magic_filter/magic.py
+++ b/magic_filter/magic.py
@@ -1,7 +1,7 @@
 import operator
 import re
 from functools import wraps
-from typing import Any, Callable, Optional, Pattern, Sequence, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Container, Optional, Pattern, Tuple, Type, TypeVar, Union
 
 from magic_filter.exceptions import RejectOperations, SwitchModeToAll, SwitchModeToAny
 from magic_filter.operations import (
@@ -217,10 +217,10 @@ class MagicFilter:
     def is_not(self: MagicT, value: Any) -> MagicT:
         return self._extend(CombinationOperation(right=value, combinator=operator.is_not))
 
-    def in_(self: MagicT, iterable: Union[Sequence[Any], Set[Any]]) -> MagicT:
+    def in_(self: MagicT, iterable: Container[Any]) -> MagicT:
         return self._extend(FunctionOperation(in_op, iterable))
 
-    def not_in(self: MagicT, iterable: Union[Sequence[Any], Set[Any]]) -> MagicT:
+    def not_in(self: MagicT, iterable: Container[Any]) -> MagicT:
         return self._extend(FunctionOperation(not_in_op, iterable))
 
     def contains(self: MagicT, value: Any) -> MagicT:

--- a/magic_filter/util.py
+++ b/magic_filter/util.py
@@ -1,28 +1,28 @@
-from typing import Any, Sequence, Set, Union
+from typing import Any, Container
 
 
-def in_op(a: Union[Sequence[Any], Set[Any]], b: Any) -> bool:
+def in_op(a: Container[Any], b: Any) -> bool:
     try:
         return b in a
     except TypeError:
         return False
 
 
-def not_in_op(a: Union[Sequence[Any], Set[Any]], b: Any) -> bool:
+def not_in_op(a: Container[Any], b: Any) -> bool:
     try:
         return b not in a
     except TypeError:
         return False
 
 
-def contains_op(a: Any, b: Union[Sequence[Any], Set[Any]]) -> bool:
+def contains_op(a: Any, b: Container[Any]) -> bool:
     try:
         return a in b
     except TypeError:
         return False
 
 
-def not_contains_op(a: Any, b: Union[Sequence[Any], Set[Any]]) -> bool:
+def not_contains_op(a: Any, b: Container[Any]) -> bool:
     try:
         return a not in b
     except TypeError:


### PR DESCRIPTION
For the `in` operation it only matters that the object implements `__contains__`.