### PR TITLE
Fix wrong type of F.func operator and fixing __slots__

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
           echo "::set-output name=dir::$(pip cache dir)"
 
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/magic_filter/magic.py
+++ b/magic_filter/magic.py
@@ -280,7 +280,7 @@ class MagicFilter:
         regexp_func = getattr(pattern, mode)
         return self._extend(FunctionOperation(regexp_func))
 
-    def func(self: MagicT, func: Callable[[Any], Any], *args: Any, **kwargs: Any) -> MagicT:
+    def func(self: MagicT, func: Callable[..., Any], *args: Any, **kwargs: Any) -> MagicT:
         return self._extend(FunctionOperation(func, *args, **kwargs))
 
     def cast(self: MagicT, func: Callable[[Any], Any]) -> MagicT:

--- a/magic_filter/operations/base.py
+++ b/magic_filter/operations/base.py
@@ -3,6 +3,8 @@ from typing import Any
 
 
 class BaseOperation(ABC):
+    __slots__ = ()
+
     important: bool = False
 
     @abstractmethod


### PR DESCRIPTION
```MagicFilter.func``` now has the same typing signature as ```maigc_filter.operations.function.FunctionOperation```

BaseOperation now has __slots__ = () for the slots to work properly in the operations